### PR TITLE
Updated to support specifying the name of the request path

### DIFF
--- a/src/OdeToCode.UseNodeModules/ApplicationBuilderExtensions.cs
+++ b/src/OdeToCode.UseNodeModules/ApplicationBuilderExtensions.cs
@@ -21,22 +21,23 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>The IApplicationBuilder object</returns>
         public static IApplicationBuilder UseNodeModules(this IApplicationBuilder app, 
                                                         IHostingEnvironment environment,
-                                                        TimeSpan? maxAge = null)
+                                                        TimeSpan? maxAge = null,
+                                                        string requestPath = "/node_modules")
         {
             if (app == null) throw new ArgumentNullException(nameof(app));
             if (environment == null) throw new ArgumentNullException(nameof(environment));
 
-            AddMiddleware(app, environment, maxAge);
+            AddMiddleware(app, environment, maxAge, requestPath);
 
             return app;
         }
 
-        private static void AddMiddleware(IApplicationBuilder app, IHostingEnvironment environment, TimeSpan? maxAge)
+        private static void AddMiddleware(IApplicationBuilder app, IHostingEnvironment environment, TimeSpan? maxAge, string requestPath)
         {
             var path = Path.Combine(environment.ContentRootPath, "node_modules");
             var provider = new PhysicalFileProvider(path);
 
-            var options = new FileServerOptions {RequestPath = "/node_modules"};
+            var options = new FileServerOptions {RequestPath = requestPath};
             options.StaticFileOptions.FileProvider = provider;
 
             if (maxAge != null)

--- a/src/OdeToCode.UseNodeModules/OdeToCode.UseNodeModules.csproj
+++ b/src/OdeToCode.UseNodeModules/OdeToCode.UseNodeModules.csproj
@@ -5,7 +5,7 @@
     <Copyright>OdeToCode LLC</Copyright>
     <VersionPrefix>1.0.5</VersionPrefix>
     <Authors>K. Scott Allen</Authors>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyName>OdeToCode.UseNodeModules</AssemblyName>
     <PackageId>OdeToCode.UseNodeModules</PackageId>
     <PackageTags>middleware;static files;node_modules</PackageTags>
@@ -20,10 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/test/OdeToCode.UseNodeModules.Tests/OdeToCode.UseNodeModules.Tests.csproj
+++ b/test/OdeToCode.UseNodeModules.Tests/OdeToCode.UseNodeModules.Tests.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>OdeToCode.UseNodeModules.Tests</AssemblyName>
     <PackageId>OdeToCode.UseNodeModules.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -16,16 +15,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="node_modules\hello.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/OdeToCode.UseNodeModules.Tests/RequestPathStartup.cs
+++ b/test/OdeToCode.UseNodeModules.Tests/RequestPathStartup.cs
@@ -1,0 +1,15 @@
+﻿namespace OdeToCode.UseNodeModules.Tests
+{
+    using System;
+
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+
+    public class RequestPathStartup
+    {
+        public void Configure(IApplicationBuilder app, IHostingEnvironment environment)
+        {
+            app.UseNodeModules(environment, TimeSpan.FromSeconds(600), "/vendor");
+        }
+    }
+}

--- a/test/OdeToCode.UseNodeModules.Tests/UseNodeModulesIntegrationTest.cs
+++ b/test/OdeToCode.UseNodeModules.Tests/UseNodeModulesIntegrationTest.cs
@@ -39,5 +39,22 @@
 
             Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
         }
-    }
+
+        [Fact]
+        public async void RespondsToFileInRequestPath()
+        {
+            var builder = new WebHostBuilder();
+            builder.UseContentRoot(Directory.GetCurrentDirectory());
+            builder.UseStartup<RequestPathStartup>();
+            var server = new TestServer(builder);
+            var client = server.CreateClient();
+
+            var result = await client.GetAsync("/vendor/hello.txt");
+
+            Assert.Equal(TimeSpan.FromSeconds(600), result.Headers.CacheControl.MaxAge);
+            Assert.Equal("hello!", await result.Content.ReadAsStringAsync());
+        }
+
+
+  }
 }


### PR DESCRIPTION
I added an optional parameter to support changing the request path from "/node_modules" to a user specified one. In addition, I upgraded it to ASP.NET Core 2.0 but this may not be what you wanted. 