### PR TITLE
Move to .NET Core 3.0

### DIFF
--- a/src/OdeToCode.UseNodeModules/ApplicationBuilderExtensions.cs
+++ b/src/OdeToCode.UseNodeModules/ApplicationBuilderExtensions.cs
@@ -1,56 +1,56 @@
 ﻿// ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Builder
 {
-    using System;
-    using System.IO;
-
-    using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.FileProviders;
+    using Microsoft.Extensions.Hosting;
     using Microsoft.Net.Http.Headers;
+    using System;
+  using System.IO;
 
-    public static class ApplicationBuilderExtensions
+  public static class ApplicationBuilderExtensions
+  {
+    /// <summary>
+    /// Configures and adds static file middleware to serve files directly from the node_modules
+    /// folder in this project
+    /// </summary>
+    /// <param name="app">The IApplicationBuilder object</param>
+    /// <param name="environment">The IHostingEnvironment object</param>
+    /// <param name="maxAge">If specified, the max time that a static file can be cached</param>
+    /// <returns>The IApplicationBuilder object</returns>
+    public static IApplicationBuilder UseNodeModules(this IApplicationBuilder app,
+                                                    TimeSpan? maxAge = null,
+                                                    string requestPath = "/node_modules")
     {
-        /// <summary>
-        /// Configures and adds static file middleware to serve files directly from the node_modules
-        /// folder in this project
-        /// </summary>
-        /// <param name="app">The IApplicationBuilder object</param>
-        /// <param name="environment">The IHostingEnvironment object</param>
-        /// <param name="maxAge">If specified, the max time that a static file can be cached</param>
-        /// <returns>The IApplicationBuilder object</returns>
-        public static IApplicationBuilder UseNodeModules(this IApplicationBuilder app, 
-                                                        IHostingEnvironment environment,
-                                                        TimeSpan? maxAge = null,
-                                                        string requestPath = "/node_modules")
-        {
-            if (app == null) throw new ArgumentNullException(nameof(app));
-            if (environment == null) throw new ArgumentNullException(nameof(environment));
+      if (app == null) throw new ArgumentNullException(nameof(app));
 
-            AddMiddleware(app, environment, maxAge, requestPath);
+      AddMiddleware(app, maxAge, requestPath);
 
-            return app;
-        }
-
-        private static void AddMiddleware(IApplicationBuilder app, IHostingEnvironment environment, TimeSpan? maxAge, string requestPath)
-        {
-            var path = Path.Combine(environment.ContentRootPath, "node_modules");
-            var provider = new PhysicalFileProvider(path);
-
-            var options = new FileServerOptions {RequestPath = requestPath};
-            options.StaticFileOptions.FileProvider = provider;
-
-            if (maxAge != null)
-            {
-                options.StaticFileOptions.OnPrepareResponse = context =>
-                    {
-                        var headers = context.Context.Response.GetTypedHeaders();
-                        headers.CacheControl = new CacheControlHeaderValue { MaxAge = maxAge, Public = true };
-                    };
-            }
-
-            options.EnableDirectoryBrowsing = false;
-            app.UseFileServer(options);
-        }
+      return app;
     }
+
+    private static void AddMiddleware(IApplicationBuilder app, TimeSpan? maxAge, string requestPath)
+    {
+
+      var environment = (IHostEnvironment)app.ApplicationServices.GetService(typeof(IHostEnvironment));
+
+      var path = Path.Combine(environment.ContentRootPath, "node_modules");
+      var provider = new PhysicalFileProvider(path);
+
+      var options = new FileServerOptions { RequestPath = requestPath };
+      options.StaticFileOptions.FileProvider = provider;
+
+      if (maxAge != null)
+      {
+        options.StaticFileOptions.OnPrepareResponse = context =>
+            {
+              var headers = context.Context.Response.GetTypedHeaders();
+              headers.CacheControl = new CacheControlHeaderValue { MaxAge = maxAge, Public = true };
+            };
+      }
+
+      options.EnableDirectoryBrowsing = false;
+      app.UseFileServer(options);
+    }
+  }
 }

--- a/src/OdeToCode.UseNodeModules/OdeToCode.UseNodeModules.csproj
+++ b/src/OdeToCode.UseNodeModules/OdeToCode.UseNodeModules.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <Description>Serve static files from node_modules in ASP.NET Core</Description>
     <Copyright>OdeToCode LLC</Copyright>
-    <VersionPrefix>1.0.6</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Authors>K. Scott Allen</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyName>OdeToCode.UseNodeModules</AssemblyName>
     <PackageId>OdeToCode.UseNodeModules</PackageId>
     <PackageTags>middleware;static files;node_modules</PackageTags>
@@ -17,18 +17,8 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/test/OdeToCode.UseNodeModules.Tests/OdeToCode.UseNodeModules.Tests.csproj
+++ b/test/OdeToCode.UseNodeModules.Tests/OdeToCode.UseNodeModules.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>OdeToCode.UseNodeModules.Tests</AssemblyName>
     <PackageId>OdeToCode.UseNodeModules.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -15,10 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0-preview-20190828-03" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0-preview9.19424.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OdeToCode.UseNodeModules.Tests/RequestPathStartup.cs
+++ b/test/OdeToCode.UseNodeModules.Tests/RequestPathStartup.cs
@@ -7,9 +7,9 @@
 
     public class RequestPathStartup
     {
-        public void Configure(IApplicationBuilder app, IHostingEnvironment environment)
+        public void Configure(IApplicationBuilder app)
         {
-            app.UseNodeModules(environment, TimeSpan.FromSeconds(600), "/vendor");
+            app.UseNodeModules(TimeSpan.FromSeconds(600), "/vendor");
         }
     }
 }

--- a/test/OdeToCode.UseNodeModules.Tests/TestStartup.cs
+++ b/test/OdeToCode.UseNodeModules.Tests/TestStartup.cs
@@ -7,9 +7,9 @@
 
     public class TestStartup
     {
-        public void Configure(IApplicationBuilder app, IHostingEnvironment environment)
+        public void Configure(IApplicationBuilder app)
         {
-            app.UseNodeModules(environment, TimeSpan.FromSeconds(600));
+            app.UseNodeModules(TimeSpan.FromSeconds(600));
         }
     }
 }


### PR DESCRIPTION
This version is using the Preview 9 bits. Not sure whether we'd want to wait to push to Nuget as a Preview version or just wait for dotnetconf bits. Your call. Let me know if you have any issues.